### PR TITLE
Add capability for evaluation/plotting of u850, u200, z500

### DIFF
--- a/ATM/run_checking/Prep/drive_preprocess.sh
+++ b/ATM/run_checking/Prep/drive_preprocess.sh
@@ -1,7 +1,9 @@
 #!/bin/bash -l
 #SBATCH -A marine-cpu
-#SBATCH --job-name=preprocess
+#SBATCH --job-name=p6_preprocess
 #SBATCH --partition=hera
+##SBATCH -q batch
+##SBATCH -t 07:30:00                 # if in debug, cannot be more than 00:30:00
 #SBATCH -q debug
 #SBATCH -t 00:30:00                 # if in debug, cannot be more than 00:30:00
 #SBATCH --nodes=1
@@ -9,29 +11,27 @@
     # Start/end delimiters for initial conditions
 
         ystart=2011; yend=2018;  ystep=1
-        mstart=1;    mend=12;    mstep=3
-        dstart=1;    dend=1;    dstep=14
+        mstart=1;    mend=12;    mstep=1
+        dstart=1;    dend=15;    dstep=14
 
     # Name and location of experiment output on HPSS
 
-       # exp_new=P4p0_uncoupled_GFS
-        exp_new=P4p0_uncoupled_GSL
-        #upload_root=/scratch1/NCEPDEV/stmp2/Lydia.B.Stefanova/fromHPSS/                # store uploaded data here
-        upload_root=/scratch2/BMC/gsd-fv3-dev/Ben.Green/WPO_S2S_35d_output/
-
-        exp_root=/scratch2/NCEPDEV/climate/Lydia.B.Stefanova/Models/
+        exp_new=ufs_p6
+        upload_root=/scratch1/NCEPDEV/stmp2/Lydia.B.Stefanova/fromHPSS/                # store uploaded grib data here
+        exp_root=/scratch2/NCEPDEV/climate/Lydia.B.Stefanova/Models/                   # store preprocessed data here
         res=1p00                                                                       # currently the only resolution implemented
+        
 
     # Specify list of variables to preprocess (turn from 6-hourly grib2 into a 35-day series of daily netcdf)
 
-        declare -a varlist=( "land" "tmpsfc" "tmp2m" "t2min" "t2max" "icetk" "icec" "ulwrftoa" "prate" ) 
         declare -a varlist=("dlwrf" "dswrf" "ulwrf" "uswrf" "pwat" "cloudbdry" "cloudlow" "cloudmid" "cloudhi")
         declare -a varlist=("soilm02m" "sfcr" "pres")
-        declare -a varlist=("shtfl" "lhtfl")
+        declare -a varlist=( "land" "tmpsfc" "tmp2m" "ulwrftoa" "prate"  "cloudbdry" "cloudlow" "cloudmid" "cloudhi" "dswrf" "u10" "pres" "pwat" ) 
+        declare -a varlist=("u850" "u200" "z500")
 
     # The plotting scripts are prepared to handle variables on the list below:
 
-        oknames=(land tmpsfc tmp2m t2min t2max ulwrftoa dlwrf dswrf ulwrf uswrf prate pwat icetk icec cloudbdry cloudlow cloudmid cloudhi snow weasd snod lhtfl shtfl pres u10 v10 uflx vflx soill01d soill14d soill41m soill12m tsoil01d tsoil14d tsoil41m tsoil12mo soilm02m sfcr)
+        oknames=(land tmpsfc tmp2m t2min t2max ulwrftoa dlwrf dswrf ulwrf uswrf prate pwat icetk icec cloudbdry cloudlow cloudmid cloudhi snow weasd snod lhtfl shtfl pres u10 v10 uflx vflx soill01d soill14d soill41m soill12m tsoil01d tsoil14d tsoil41m tsoil12mo soilm02m sfcr u850 u200 z500)
 
 
 #====================================================================================================

--- a/ATM/run_checking/Prep/get_exp.sh
+++ b/ATM/run_checking/Prep/get_exp.sh
@@ -4,19 +4,19 @@
 #SBATCH -A marine-cpu
 #SBATCH -J b31-getfiles
 
+set -x
 module load hpss
 
     # Start/end delimiters for cases to get
 
-        ystart=2013; yend=2013;  ystep=1
-        mstart=2;    mend=12;    mstep=6
-        dstart=1;    dend=1;    dstep=14
+        ystart=2011; yend=2018;  ystep=1
+        mstart=1;    mend=12;    mstep=1
+        dstart=1;    dend=15;    dstep=14
 
     # Name and location of experiment output on HPSS
 
-        exp_new=ufs_p4
-        #hpss_root=/NCEPDEV/emc-climate/5year/Jiande.Wang/WCOSS/scratch/preUFSp4/c384/  # upload data from here
-        hpss_root=/NCEPDEV/emc-climate/5year/Jiande.Wang/WCOSS/benchmark4.0/c384/
+        exp_new=ufs_p6
+        hpss_root=/NCEPDEV/emc-climate/5year/Jiande.Wang/HERA/prototype6.0/c384/       # location on HPSS
         upload_root=/scratch1/NCEPDEV/stmp2/Lydia.B.Stefanova/fromHPSS/                # store uploaded data here
 
 #===================================================================================================================
@@ -28,15 +28,25 @@ for exp in $exp_new ; do
         mm=$(printf "%02d" $mm1)
         dd=$(printf "%02d" $dd1)
         tag=$yyyy$mm${dd}00
-        if [ ! -f ${upload_location}/$tag/gfs.$yyyy$mm$dd/00/gfs.t00z.flux.1p00.f840 ] ; then 
+        if [ ! -f ${upload_location}/$tag/gfs.$yyyy$mm$dd/00/atmos/gfs.t00z.flux.1p00.f840 ] ; then 
            hpss_location=${hpss_root}/$tag
            atmflux1p00=gfs_flux_1p00.tar
-           echo "Working on $tag for $exp"
+           echo "Working on $tag for $exp flux.1p00"
            mkdir -p ${upload_location}/$tag
            cd ${upload_location}/$tag
            htar -xvf ${hpss_location}/$atmflux1p00
         else
-           echo "$exp $tag  already uploaded" 
+           echo "$exp $tag flux.1p00 already uploaded" 
+        fi
+        if [ ! -f ${upload_location}/$tag/gfs.$yyyy$mm$dd/00/atmos/gfs.t00z.pgrb2.1p00.f840 ] ; then
+           hpss_location=${hpss_root}/$tag
+           atmpgrb1p00=gfs_pgrb2_1p00.tar
+           echo "Working on $tag for $exp pgrb2.1p00"
+           mkdir -p ${upload_location}/$tag
+           cd ${upload_location}/$tag
+           htar -xvf ${hpss_location}/$atmpgrb1p00
+        else
+           echo "$exp $tag pgrb2.1p00 already uploaded" 
         fi
     done
     done

--- a/ATM/run_checking/WithObs/Lines/anoms12.sh
+++ b/ATM/run_checking/WithObs/Lines/anoms12.sh
@@ -54,10 +54,23 @@ case "$domain" in
     "NP") latS="50"; latN="90" ;  lonW="0" ; lonE="360" ;;
     "SP") latS="-90"; latN="-50" ;  lonW="0" ; lonE="360" ;;
     "DatelineEq") latS="-1"; latN="1" ;  lonW="179" ; lonE="181" ;;
+    "Maritime") latS="-10"; latN="10" ; lonW="90" ; lonE="150" ;;
     *)
 esac
 
        mask=$mask
+       if [ "$varModel" == "u850" ] ; then
+          ncvarModel="UGRD_850mb"; multModel=1.; offsetModel=0.; units="m/s"
+          nameObs="${reference:-era5}";  varObs="u850"; ncvarObs="UGRD_850mb"; multObs=1.; offsetObs=0.
+       fi
+       if [ "$varModel" == "u200" ] ; then
+          ncvarModel="UGRD_200mb"; multModel=1.; offsetModel=0.; units="m/s"
+          nameObs="${reference:-era5}";  varObs="u200"; ncvarObs="UGRD_200mb"; multObs=1.; offsetObs=0.
+       fi
+       if [ "$varModel" == "z500" ] ; then
+          ncvarModel="HGT_500mb"; multModel=1.; offsetModel=0.; units="m"
+          nameObs="${reference:-era5}";  varObs="z500"; ncvarObs="HGT_500mb"; multObs=1.; offsetObs=0.
+       fi
        if [ "$varModel" == "t2max" ] ; then
           ncvarModel="TMAX_2maboveground"; multModel=1.; offsetModel=0.; units="deg K"
           nameObs="t2max_CPC";  varObs="tmax"; ncvarObs="tmax"; multObs=1.; offsetObs=273.15
@@ -425,7 +438,7 @@ cat << EOF > $nclscript
   res@gsnFrame            = False                          ; don't advance frame
   res@xyLineThicknesses = (/10.0, 10.0,  10.0/)          ; make second line thicker
   res@xyLineColors      = (/"red", "blue", "black"/)          ; change line color
-  res@xyLineColors      = (/"blue", "orange", "black"/)          ; change line color
+  res@xyLineColors      = (/"blue", "red", "black"/)          ; change line color
   res@xyExplicitLegendLabels = (/"${nameModelA}", "${nameModelB}", "${nameObs}"/)
  ; res@tiMainString      = "$domain, $season,  $truelength ICs, $mask"       ; add title
   res@gsnYRefLine = 0
@@ -437,6 +450,9 @@ cat << EOF > $nclscript
   res@pmLegendWidthF         = 0.08                  ; Change width and
   res@lgLabelFontHeightF     = .02                   ; change font height
   res@lgPerimOn              = False                 ; no box around
+  
+  ;res@tmXMajorGrid=True
+  res@tmYMajorGrid=True
 
   res0=res
   res1=res
@@ -545,7 +561,8 @@ cat << EOF > $nclscript
   panelopts@gsnPanelYWhiteSpacePercent = 0
   panelopts@gsnPanelXWhiteSpacePercent = 5
   panelopts@amJust   = "TopLeft"
-  gsn_panel(wks,plot,(/2,2/),panelopts)
+  ;gsn_panel(wks,plot(0:2),(/1,2/),panelopts)
+  gsn_panel(wks,plot(0:2),(/3/),panelopts)
 
 
 EOF

--- a/ATM/run_checking/WithObs/Lines/anoms12.sh
+++ b/ATM/run_checking/WithObs/Lines/anoms12.sh
@@ -232,7 +232,7 @@ cat << EOF > $nclscript
      wks_type@wkHeight            = 800
   end if 
 
-  wks                          = gsn_open_wks(wks_type,"rmse.${varModel}.${nameModelA}.${nameModelB}.${season}.${ystart}-${yend}.${truelength}IC.$domain.$mask")
+  wks                          = gsn_open_wks(wks_type,"rmse.${varModel}.${nameModelA}.${nameModelB}.${nameObs}.${season}.${ystart}-${yend}.${truelength}IC.$domain.$mask")
 
   latStart=${latS}
   latEnd=${latN}

--- a/ATM/run_checking/WithObs/Lines/drive_anoms.sh
+++ b/ATM/run_checking/WithObs/Lines/drive_anoms.sh
@@ -18,52 +18,38 @@
         whereexp=$exp_root
         whereobs=$obs_root
 
-        exp_old=ufs_p4
-        exp_new=ufs_p5
+        exp_old=ufs_p5
+        exp_new=ufs_p6
         res=1p00
 
     # Other specitications
 
-
         hardcopy=no         # Valid choices are yes no      
-        domain=Global       # Valid choices see [case "$domain" list] in mapping script
-                            # NB: keep in mind that verifying obs for tmpsfc (OSTIA SST) are not valid for ice-covered areas because tmpsfc there is not sst
-
         reference=cfsr      # Valid choices are cfsr or era5; this choice currently only applies to tmp2m; if not specified, defaults to era5
 
-        declare -a varlist=("tmp2m" )            # Valid choices for comparison with OBS are "tmpsfc" "prate" "ulwrftoa" "tmp2m" "t2min" "t2max" 
-        declare -a seasonlist=( "JJA" "DJF" "AllAvailable")     # Valid choices are "DJF" "MAM" "JJA" "SON" "AllAvailable"
+        declare -a varlist=("tmp2m" "z500")            # Valid choices for comparison with OBS are "tmpsfc" "prate" "ulwrftoa" "tmp2m" "t2min" "t2max" 
+        declare -a seasonlist=( "AllAvailable")     # Valid choices are "DJF" "MAM" "JJA" "SON" "AllAvailable"
        
 
-
-
 for season in "${seasonlist[@]}" ; do
-        #for domain in GlobalTropics Global50  ; do
-        for domain in Global50  ; do
+        for domain in GlobalTropics Maritime ; do # Global Nino34 GlobalTropics ; do
 
-           # varname="tmpsfc"; mask="oceanonly"
-           # bash anoms12.sh whereexp=$whereexp whereobs=$whereobs varModel=$varname domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp_old nameModelB=$exp_new  ystart=$ystart yend=$yend ystep=$ystep mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep mask=$mask
-
-           #varname="t2max"; mask="landonly"
-           # bash anoms12.sh whereexp=$whereexp whereobs=$whereobs varModel=$varname domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp_old nameModelB=$exp_new  ystart=$ystart yend=$yend ystep=$ystep mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep mask=$mask
-
-            #varname="t2min"; mask="landonly"
-            #bash anoms12.sh whereexp=$whereexp whereobs=$whereobs varModel=$varname domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp_old nameModelB=$exp_new  ystart=$ystart yend=$yend ystep=$ystep mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep mask=$mask
-
-            varname="tmp2m"; mask="landonly"
+            varname="z500"; mask="nomask"
             bash anoms12.sh whereexp=$whereexp whereobs=$whereobs varModel=$varname domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp_old nameModelB=$exp_new  ystart=$ystart yend=$yend ystep=$ystep mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep mask=$mask reference=$reference
-
-            varname="prate"; mask="nomask"
-            bash anoms12.sh whereexp=$whereexp whereobs=$whereobs varModel=$varname domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp_old nameModelB=$exp_new  ystart=$ystart yend=$yend ystep=$ystep mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep mask=$mask
-
-           # varname="ulwrftoa"; mask="landonly"
-           # bash anoms12.sh whereexp=$whereexp whereobs=$whereobs varModel=$varname domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp_old nameModelB=$exp_new  ystart=$ystart yend=$yend ystep=$ystep mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep mask=$mask
-           # varname="ulwrftoa"; mask="oceanonly"
-           # bash anoms12.sh whereexp=$whereexp whereobs=$whereobs varModel=$varname domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp_old nameModelB=$exp_new  ystart=$ystart yend=$yend ystep=$ystep mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep mask=$mask
+            varname="u850"; mask="nomask"
+            bash anoms12.sh whereexp=$whereexp whereobs=$whereobs varModel=$varname domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp_old nameModelB=$exp_new  ystart=$ystart yend=$yend ystep=$ystep mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep mask=$mask reference=$reference
+            varname="u200"; mask="nomask"
+            bash anoms12.sh whereexp=$whereexp whereobs=$whereobs varModel=$varname domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp_old nameModelB=$exp_new  ystart=$ystart yend=$yend ystep=$ystep mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep mask=$mask reference=$reference
+            varname="tmpsfc"; mask="oceanonly"
+            #bash anoms12.sh whereexp=$whereexp whereobs=$whereobs varModel=$varname domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp_old nameModelB=$exp_new  ystart=$ystart yend=$yend ystep=$ystep mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep mask=$mask reference=$reference
+            varname="tmp2m"; mask="nomask"
+            #bash anoms12.sh whereexp=$whereexp whereobs=$whereobs varModel=$varname domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp_old nameModelB=$exp_new  ystart=$ystart yend=$yend ystep=$ystep mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep mask=$mask reference=$reference
             varname="ulwrftoa"; mask="nomask"
-            bash anoms12.sh whereexp=$whereexp whereobs=$whereobs varModel=$varname domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp_old nameModelB=$exp_new  ystart=$ystart yend=$yend ystep=$ystep mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep mask=$mask
+            #bash anoms12.sh whereexp=$whereexp whereobs=$whereobs varModel=$varname domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp_old nameModelB=$exp_new  ystart=$ystart yend=$yend ystep=$ystep mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep mask=$mask reference=$reference
+            varname="prate"; mask="nomask"
+            #bash anoms12.sh whereexp=$whereexp whereobs=$whereobs varModel=$varname domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp_old nameModelB=$exp_new  ystart=$ystart yend=$yend ystep=$ystep mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep mask=$mask reference=$reference
 
+            done
         done
-done
 
 

--- a/ATM/run_checking/WithObs/Maps/drive_map_obs.sh
+++ b/ATM/run_checking/WithObs/Maps/drive_map_obs.sh
@@ -8,7 +8,7 @@
     # Start/end delimiters for initial conditions
 
         ystart=2011; yend=2018;  ystep=1
-        mstart=1;    mend=12;    mstep=3
+        mstart=1;    mend=12;    mstep=1
         dstart=1;    dend=15;     dstep=14
 
     # Name and location of experiment and obs (data as 35-day time series in netcdf)
@@ -18,8 +18,8 @@
         whereexp=$exp_root
         whereobs=$obs_root
 
-        exp_old=ufs_p4
-        exp_new=ufs_p5
+        exp_old=ufs_p5
+        exp_new=ufs_p6
 
         res=1p00
 
@@ -35,18 +35,23 @@
         hardcopy=no                # Valid choices are yes no      
         domain=GlobalTropics       # Valid choices see [case "$domain" list] in mapping script
         domain=Global              # Valid choices see [case "$domain" list] in mapping script
-        reference=cfsr             # Current valid choudes are era5 and cfsr; currently only used for tmp2m; if omitted, defaults to era5
+        reference=cfsr             # Current valid choudes are era5 and cfsr; if omitted, defaults to era5
 
       # NB: keep in mind that verifying obs for tmpsfc (OSTIA SST) are not valid for ice-covered areas because tmpsfc there is not sst
-        declare -a varlist=("tmp2m" "tmpsfc" )  # Current valid choices for comparison with OBS are "tmpsfc" "prate" "ulwrftoa" "tmp2m" "t2min" "t2max" 
-        declare -a seasonlist=("JJA" "AllAvailable")     # Valid choices are "DJF" "MAM" "JJA" "SON" "AllAvailable"
+        declare -a varlist=("z500" "tmpsfc" "tmp2m" "prate" "ulwrftoa" "u200" "u850"  )  # Current valid choices for comparison with OBS are "tmpsfc" "prate" "ulwrftoa" "tmp2m" "t2min" "t2max" 
+        declare -a varlist=("tmp2m")
+        reference=era5
+        declare -a seasonlist=("AllAvailable")     # Valid choices are "DJF" "MAM" "JJA" "SON" "AllAvailable"
 
         for season in ${seasonlist[@]} ; do
             for varname in ${varlist[@]}; do
-                day1=14; day2=28
+                day1=15; day2=28
                 echo "using $mapscript $day1 to $day2 for $varname"
                 bash $mapscript whereexp=$whereexp  whereobs=$whereobs varModel=$varname reference=$reference domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp_old nameModelB=$exp_new ystart=$ystart yend=$yend ystep=$ystep  mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep d1=`expr $day1 - 1` d2=`expr $day2 - 1`  nplots=$nplots
 
+                day1=1; day2=7
+                echo "using $mapscript $day1 to $day2 for $varname"
+                bash $mapscript whereexp=$whereexp  whereobs=$whereobs varModel=$varname reference=$reference domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp_old nameModelB=$exp_new ystart=$ystart yend=$yend ystep=$ystep  mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep d1=`expr $day1 - 1` d2=`expr $day2 - 1`  nplots=$nplots
 done
 done
 

--- a/ATM/run_checking/WithObs/Maps/map_compare_obs.sh
+++ b/ATM/run_checking/WithObs/Maps/map_compare_obs.sh
@@ -225,7 +225,7 @@ cat << EOF > $nclscript
      wks_type@wkHeight            = 800
   end if 
 
-  wks                          = gsn_open_wks(wks_type,"biasmaps.${varModel}.${nameModelB}.vs.${nameModelA}.${season}.${startname}.$domain.d${d1p1}-d${d2p1}")
+  wks                          = gsn_open_wks(wks_type,"biasmaps.${varModel}.${nameModelB}.vs.${nameModelA}.${nameObs}.${season}.${startname}.$domain.d${d1p1}-d${d2p1}")
 
   latStart=${latS}
   latEnd=${latN}

--- a/ATM/run_checking/WithObs/Maps/map_compare_obs.sh
+++ b/ATM/run_checking/WithObs/Maps/map_compare_obs.sh
@@ -56,6 +56,18 @@ case "$domain" in
     *)
 esac
 
+       if [ "$varModel" == "u200" ] ; then
+          ncvarModel="UGRD_200mb"; multModel=1.; offsetModel=0.; units="m/s";mask="nomask"
+          nameObs="${reference:-era5}";  varObs="u200"; ncvarObs="UGRD_200mb"; multObs=1.; offsetObs=0.
+       fi
+       if [ "$varModel" == "u850" ] ; then
+          ncvarModel="UGRD_850mb"; multModel=1.; offsetModel=0.; units="m/s";mask="nomask"
+          nameObs="${reference:-era5}";  varObs="u850"; ncvarObs="UGRD_850mb"; multObs=1.; offsetObs=0.
+       fi
+       if [ "$varModel" == "z500" ] ; then
+          ncvarModel="HGT_500mb"; multModel=1.; offsetModel=0.; units="m";mask="nomask"
+          nameObs="${reference:-era5}";  varObs="z500"; ncvarObs="HGT_500mb"; multObs=1.; offsetObs=0.
+       fi
        if [ "$varModel" == "t2max" ] ; then
           ncvarModel="TMAX_2maboveground"; multModel=1.; offsetModel=0.; units="deg K"; mask="landonly"
           nameObs="t2max_CPC";  varObs="tmax"; ncvarObs="tmax"; multObs=1.; offsetObs=273.15
@@ -69,9 +81,8 @@ esac
           nameObs="t2m_from_minmax_CPC";  varObs="t2m_CPC"; ncvarObs="t2m"; multObs=1.; offsetObs=273.15
        fi
        if [ "$varModel" == "tmp2m" ] ; then
-          ncvarModel="TMP_2maboveground"; multModel=1.; offsetModel=0.; units="deg K";mask="landonly"
+          ncvarModel="TMP_2maboveground"; multModel=1.; offsetModel=0.; units="deg K";mask="nomask"
           nameObs="${reference:-era5}";  varObs="t2m"; ncvarObs="TMP_2maboveground"; multObs=1.; offsetObs=0.
-
        fi
        if [ "$varModel" == "tmpsfc" ] ; then
           ncvarModel="TMP_surface"; multModel=1.; offsetModel=0.; units="deg K";mask="oceanonly"

--- a/ATM/run_checking/WithObs/drive_pdf.sh
+++ b/ATM/run_checking/WithObs/drive_pdf.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -l
+#SBATCH -A fv3-cpu        # -A specifies the account
+#SBATCH -n 1                 # -n specifies the number of tasks (cores) (-N would be for number of nodes) 
+#SBATCH --exclusive          # exclusive use of node - hoggy but OK
+#SBATCH -q debug             # -q specifies the queue; debug has a 30 min limit, but the default walltime is only 5min, to change, see below:
+#SBATCH -t 30                # -t specifies walltime in minutes; if in debug, cannot be more than 30
+#
+#
+# This is a tiny little package that compares two sets of (exp1 and exp2) for a chosen variable, domain, season
+# top directory with preprocessed files 
+
+    whereexp=$noscrub/Models
+    whereobs=$noscrub/ReferenceData
+    
+    hardcopy=yes                        # yes | no
+
+    ystart=2011; yend=2018
+    mstart=1; mend=12; mstep=1
+    dstart=1; dend=15; dstep=100
+
+    exp1=ufs_p5
+    exp2=ufs_p6
+    reference=cfsr
+
+# The scripts are prepared to handle variables on the list below 
+    oknames=(land tmpsfc tmp2m t2min t2max ulwrftoa dlwrf dswrf ulwrf uswrf prate pwat icetk icec cloudbdry cloudlow cloudmid cloudhi snow weasd snod lhtfl shtfl pres u10 v10 uflx vflx )
+
+ domain=Global20 
+ #for season in MAM JJA SON DJF AllAvailable ; do
+ for domain in Maritime ; do #Nino34 GlobalTropics Global ; do
+ for season in AllAvailable; do
+     bash pdf.sh whereexp=$whereexp whereobs=$whereobs varModel=z500 reference=$reference domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp1 nameModelB=$exp2  ystart=$ystart yend=$yend mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep mask=nomask
+     bash pdf.sh whereexp=$whereexp whereobs=$whereobs varModel=u850 reference=$reference domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp1 nameModelB=$exp2  ystart=$ystart yend=$yend mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep mask=nomask
+     bash pdf.sh whereexp=$whereexp whereobs=$whereobs varModel=u200 reference=$reference domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp1 nameModelB=$exp2  ystart=$ystart yend=$yend mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep mask=nomask
+#     bash pdf.sh whereexp=$whereexp whereobs=$whereobs varModel=tmp2m reference=$reference domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp1 nameModelB=$exp2  ystart=$ystart yend=$yend mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep mask=nomask
+#     bash pdf.sh whereexp=$whereexp whereobs=$whereobs varModel=ulwrftoa domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp1 nameModelB=$exp2  ystart=$ystart yend=$yend mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep mask=nomask
+#     bash pdf.sh whereexp=$whereexp whereobs=$whereobs varModel=tmpsfc domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp1 nameModelB=$exp2  ystart=$ystart yend=$yend mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep mask=oceanonly
+#     bash pdf.sh whereexp=$whereexp whereobs=$whereobs varModel=prate domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp1 nameModelB=$exp2  ystart=$ystart yend=$yend mstart=$mstart mend=$mend mstep=$mstep dstart=$dstart dend=$dend dstep=$dstep mask=nomask
+ done
+ done
+
+

--- a/ATM/run_checking/WithObs/pdf.sh
+++ b/ATM/run_checking/WithObs/pdf.sh
@@ -10,6 +10,7 @@
 #
 # The result is a four-panel plot with time series of a) area mean, b) area mean bias, c) raw RMS, d) bias-corrected RMS
 
+module load ncl
 
 for ARGUMENT in "$@"
 do
@@ -234,7 +235,7 @@ cat << EOF > $nclscript
      wks_type@wkHeight            = 800
   end if 
 
-  wks                          = gsn_open_wks(wks_type,"biaspdf.${varModel}.${nameModelA}.${nameModelB}.${season}.${truelength}ICs.$domain.$mask")
+  wks                          = gsn_open_wks(wks_type,"biaspdf.${varModel}.${nameModelA}.${nameModelB}.${nameObs}.${season}.${truelength}ICs.$domain.$mask")
 
   latStart=${latS}
   latEnd=${latN}

--- a/ATM/run_checking/WithObs/pdf.sh
+++ b/ATM/run_checking/WithObs/pdf.sh
@@ -1,0 +1,457 @@
+#!/bin/bash -l
+#SBATCH -A marine-cpu        # -A specifies the account
+#SBATCH -n 1                 # -n specifies the number of tasks (cores) (-N would be for number of nodes) 
+#SBATCH --exclusive          # exclusive use of node - hoggy but OK
+#SBATCH -q debug             # -q specifies the queue; debug has a 30 min limit, but the default walltime is only 5min, to change, see below:
+#SBATCH -t 30               # -t specifies walltime in minutes; if in debug, cannot be more than 30
+
+# (proper RMSe calculation version)
+# Creates and runs ncl script with given specifications for paths, names, and preferences
+#
+# The result is a four-panel plot with time series of a) area mean, b) area mean bias, c) raw RMS, d) bias-corrected RMS
+
+
+for ARGUMENT in "$@"
+do
+    KEY=$(echo $ARGUMENT | cut -f1 -d=)
+    VALUE=$(echo $ARGUMENT | cut -f2 -d=)
+    case "$KEY" in
+            whereexp)   whereexp=${VALUE} ;;             # path to models
+            whereobs)   whereobs=${VALUE} ;;             # path to OBS
+            hardcopy)   hardcopy=${VALUE} ;;             # yes/no hardcopy
+            domain)     domain=${VALUE} ;;               # choice of preset domains
+            varModel)   varModel=${VALUE} ;;             # model variable name
+            reference)  reference=${VALUE} ;;
+            season)     season=${VALUE} ;;               # choice of DJF, MAM, JJA, SON
+            nameModelA) nameModelA=${VALUE} ;;           # name of first experiment
+            nameModelB) nameModelB=${VALUE} ;;           # name of second experiment
+            ystart)     ystart=${VALUE} ;;               # first year to consider
+            yend)       yend=${VALUE} ;;                 # last year to consider
+            mstart)     mstart=${VALUE} ;;               # first month to consider
+            mend)       mend=${VALUE} ;;                 # last month to consider
+            mstep)      mstep=${VALUE} ;;                # interval between months to consider
+            dstart)     dstart=${VALUE} ;;               # first month to consider
+            dend)       dend=${VALUE} ;;                 # last month to consider
+            dstep)      dstep=${VALUE} ;;                # interval between months to consider
+            mask)       mask=${VALUE} ;;             # oceanonly/landonly/none
+            *)
+    esac
+done
+
+case "$domain" in 
+    "Global") latS="-90"; latN="90" ;  lonW="0" ; lonE="360" ;;
+    "Nino3.4") latS="-5"; latN="5" ;  lonW="190" ; lonE="240" ;;
+    "GlobalTropics") latS="-30"; latN="30" ;  lonW="0" ; lonE="360" ;;
+    "Global20") latS="-20"; latN="20" ;  lonW="0" ; lonE="360" ;;
+    "Global50") latS="-50"; latN="50" ;  lonW="0" ; lonE="360" ;;
+    "Global60") latS="-60"; latN="90" ;  lonW="0" ; lonE="360" ;;
+    "CONUS") latS="25"; latN="60" ;  lonW="210" ; lonE="300" ;;
+    "NAM") latS="0"; latN="90" ;  lonW="180" ; lonE="360" ;;
+    "IndoChina") latS="-20"; latN="40" ;  lonW="30" ; lonE="150" ;;
+    "NP") latS="50"; latN="90" ;  lonW="0" ; lonE="360" ;;
+    "SP") latS="-90"; latN="-50" ;  lonW="0" ; lonE="360" ;;
+    "DatelineEq") latS="-1"; latN="1" ;  lonW="179" ; lonE="181" ;;
+    "Maritime") latS="-10"; latN="10" ; lonW="90" ; lonE="150" ;;
+    *)
+esac
+
+       mask=$mask
+       if [ "$varModel" == "u200" ] ; then
+          ncvarModel="UGRD_200mb"; multModel=1.; offsetModel=0.; units="m/s"
+          nameObs="${reference:-era5}";  varObs="u200"; ncvarObs="UGRD_200mb"; multObs=1.; offsetObs=0.
+          cmin=-5.; cmax=5.
+       fi
+       if [ "$varModel" == "u850" ] ; then
+          ncvarModel="UGRD_850mb"; multModel=1.; offsetModel=0.; units="m/s"
+          nameObs="${reference:-era5}";  varObs="u850"; ncvarObs="UGRD_850mb"; multObs=1.; offsetObs=0.
+          cmin=-5.; cmax=5.
+       fi
+       if [ "$varModel" == "z500" ] ; then
+          ncvarModel="HGT_500mb"; multModel=1.; offsetModel=0.; units="m"
+          nameObs="${reference:-era5}";  varObs="z500"; ncvarObs="HGT_500mb"; multObs=1.; offsetObs=0.
+          cmin=-40.; cmax=40.
+       fi
+       if [ "$varModel" == "t2max" ] ; then
+          ncvarModel="TMAX_2maboveground"; multModel=1.; offsetModel=0.; units="deg K"
+          nameObs="t2max_CPC";  varObs="tmax"; ncvarObs="tmax"; multObs=1.; offsetObs=273.15
+          cmin=-5.; cmax=5.
+       fi
+       if [ "$varModel" == "t2min" ] ; then
+          ncvarModel="TMIN_2maboveground"; multModel=1.; offsetModel=0.; units="deg K"
+          nameObs="t2min_CPC";  varObs="tmin"; ncvarObs="tmin"; multObs=1.; offsetObs=273.15
+          cmin=-5.; cmax=5.
+       fi
+       if [ "$varModel" == "tmp2m" ] ; then
+          ncvarModel="TMP_2maboveground"; multModel=1.; offsetModel=0.; units="deg K"
+          nameObs="${reference:-era5}";  varObs="t2m"; ncvarObs="TMP_2maboveground"; multObs=1.; offsetObs=0.
+          cmin=-5.; cmax=5.
+       fi
+       if [ "$varModel" == "tmpsfc" ] ; then
+          ncvarModel="TMP_surface"; multModel=1.; offsetModel=0.; units="deg K"
+          nameObs="sst_OSTIA";  varObs="sst_OSTIA"; ncvarObs="analysed_sst"; multObs=1.; offsetObs=0.
+          cmin=-2.; cmax=2.
+       fi
+       if [ "$varModel" == "prate" ] ; then
+          ncvarModel="PRATE_surface"; multModel=86400.; offsetModel=0.; units="mm/day"
+          nameObs="pcp_CPC_Global";  varObs="rain"; ncvarObs="rain"; multObs=0.1; offsetObs=0.
+          nameObs="pcp_TRMM";  varObs="pcp-TRMM"; ncvarObs="precipitation"; multObs=1; offsetObs=0.
+          cmin=-5.; cmax=5.
+       fi
+       if [ "$varModel" == "ulwrftoa" ] ; then
+          ncvarModel="ULWRF_topofatmosphere"; multModel=1.; offsetModel=0.; units="W/m^2"
+          nameObs="olr_HRIS"; varObs="ulwrftoa"; ncvarObs="olr"; multObs=1.; offsetObs=0.; units="W/m^2"
+          cmin=-40.; cmax=40.
+       fi
+
+# Names for the anomaly arrays
+       nameModelBA=${nameModelB}_minus_${nameModelA}
+       nameModelA0=${nameModelA}_minus_${nameObs}
+       nameModelB0=${nameModelB}_minus_${nameObs}
+ 
+# Clean up file listings from last time
+    
+       if [ -f ${varModel}-${nameModelA}-list.txt ] ; then rm ${varModel}-${nameModelA}-list.txt ; fi
+       if [ -f ${varModel}-${nameModelB}-list.txt ] ; then rm ${varModel}-${nameModelB}-list.txt ; fi
+       if [ -f ${varModel}-${nameObs}-list.txt ] ; then rm ${varModel}-${nameObs}-list.txt ; fi
+
+# Create file listings from which to read matching dates for model and obs data
+
+       LENGTH=0   # Total length of each file listing
+
+       for (( yyyy=$ystart; yyyy<=$yend; yyyy+=1 ))  ; do
+       for (( mm1=$mstart; mm1<=$mend; mm1+=$mstep )) ; do
+       for (( dd1=$dstart; dd1<=$dend; dd1+=$dstep )) ; do
+           mm=$(printf "%02d" $mm1)
+           dd=$(printf "%02d" $dd1)
+           tag=$yyyy$mm${dd}
+           if [ -f $whereexp/$nameModelA/1p00/dailymean/${tag}/${varModel}.${nameModelA}.${tag}.dailymean.1p00.nc ] ; then
+              if [ -f $whereexp/$nameModelB/1p00/dailymean/${tag}/${varModel}.${nameModelB}.${tag}.dailymean.1p00.nc ] ; then
+                  pathObs="$whereobs/$nameObs/1p00/dailymean"
+                  if [ "$nameObs" == "pcp_TRMM" ] ;  then
+                      pathObs="$whereobs/$nameObs/1p00"
+                  fi
+
+                  if [ -f $pathObs/${varObs}.day.mean.${tag}.1p00.nc ] ; then
+                   
+                   
+                  case "${season}" in
+                      *"DJF"*)
+                          if [ $mm1 -ge 12 ] || [ $mm1 -le 2 ] ; then
+                             for nameModel in $nameModelA $nameModelB ; do
+                                 pathModel="$whereexp/$nameModel/1p00/dailymean"
+                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.1p00.nc >> ${varModel}-${nameModel}-list.txt
+                             done
+	                         ls -d -1 $pathObs/${varObs}.day.mean.${tag}.1p00.nc >> ${varModel}-${nameObs}-list.txt
+                                 LENGTH="$(($LENGTH+1))"                       
+                          fi
+                      ;;
+                      *"MAM"*)
+                          if [ $mm1 -ge 3 ] && [ $mm1 -le 5 ] ; then
+                             for nameModel in $nameModelA $nameModelB ; do
+                                 pathModel="$whereexp/$nameModel/1p00/dailymean"
+                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.1p00.nc >> ${varModel}-${nameModel}-list.txt
+                             done
+	                         ls -d -1 $pathObs/${varObs}.day.mean.${tag}.1p00.nc >> ${varModel}-${nameObs}-list.txt
+                                 LENGTH="$(($LENGTH+1))"                      
+                          fi
+                      ;;
+                      *"JJA"*)
+                          if [ $mm1 -ge 6 ] && [ $mm1 -le 8 ] ; then
+                             for nameModel in $nameModelA $nameModelB ; do
+                                 pathModel="$whereexp/$nameModel/1p00/dailymean"
+                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.1p00.nc >> ${varModel}-${nameModel}-list.txt
+                             done
+	                         ls -d -1 $pathObs/${varObs}.day.mean.${tag}.1p00.nc >> ${varModel}-${nameObs}-list.txt
+                                 LENGTH="$(($LENGTH+1))"                     
+                          fi
+                      ;;
+                      *"SON"*)
+                          if [ $mm1 -ge 9 ] && [ $mm1 -le 11 ] ; then
+                             for nameModel in $nameModelA $nameModelB ; do
+                                 pathModel="$whereexp/$nameModel/1p00/dailymean"
+                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.1p00.nc >> ${varModel}-${nameModel}-list.txt
+                             done
+	                         ls -d -1 $pathObs/${varObs}.day.mean.${tag}.1p00.nc >> ${varModel}-${nameObs}-list.txt
+                                 LENGTH="$(($LENGTH+1))"                   
+                          fi
+                      ;;
+                      *"AllAvailable"*)
+                             for nameModel in $nameModelA $nameModelB ; do
+                                 pathModel="$whereexp/$nameModel/1p00/dailymean"
+                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.1p00.nc >> ${varModel}-${nameModel}-list.txt
+                             done
+	                         ls -d -1 $pathObs/${varObs}.day.mean.${tag}.1p00.nc >> ${varModel}-${nameObs}-list.txt
+                                 LENGTH="$(($LENGTH+1))"                  
+                      ;;
+                 esac
+
+              fi
+           fi
+           fi
+       done
+       done
+       done
+
+   echo "A total of $LENGTH ICs are being processed"
+   truelength=$LENGTH
+
+# The if below takes care of the situation where there is a single IC by listing it twice (so that it can still be read with "addfiles")
+   if [ $LENGTH -eq 1 ] ; then
+                             for nameModel in $nameModelA $nameModelB ; do
+                              cat ${varModel}-${nameModel}-list.txt ${varModel}-${nameModel}-list.txt > tmp.txt
+                              mv tmp.txt ${varModel}-${nameModel}-list.txt
+                             done
+                              cat ${varModel}-${nameObs}-list.txt ${varModel}-${nameObs}-list.txt > tmp.txt
+                              mv tmp.txt ${varModel}-${nameObs}-list.txt
+                                 LENGTH="$(($LENGTH+1))"                       # How many ICs are considered
+   fi
+#
+
+   echo "A total of $truelength ICs are being processed"
+
+   LENGTHm1="$(($LENGTH-1))"                          # Needed for counters starting at 0
+   s1=0; s2=$LENGTHm1                                 # Glom together all ICs
+   d1=0; d2=34                                        # from day=d1 to day=d1 (counter starting at 0)
+   d1p1="$(($d1+1))"                                  # day1 (counter starting at 1)
+   d2p1="$(($d2+1))"                                  # day2 (counter starting at 1)
+
+###################################################################################################
+#                                            Create ncl script
+###################################################################################################
+
+nclscript="pdf_${season}.ncl"                         # Name for the NCL script to be created
+
+
+cat << EOF > $nclscript
+
+  if isStrSubset("$hardcopy","yes") then
+     wks_type                     = "png"
+     wks_type@wkWidth             = 3000
+     wks_type@wkHeight            = 3000
+  else
+     wks_type                     = "x11"
+     wks_type@wkWidth             = 1200
+     wks_type@wkHeight            = 800
+  end if 
+
+  wks                          = gsn_open_wks(wks_type,"biaspdf.${varModel}.${nameModelA}.${nameModelB}.${season}.${truelength}ICs.$domain.$mask")
+
+  latStart=${latS}
+  latEnd=${latN}
+  lonStart=${lonW}
+  lonEnd=${lonE}
+
+  if isStrSubset("$domain","Global") then
+     lonStart=30
+     lonEnd=390
+  end if
+
+  
+  ${nameModelA}_list=systemfunc ("if [ -f  ${varModel}-${nameModelA}-list.txt ] ; then awk  '{print} NR==${LENGTH}{exit}' ${varModel}-${nameModelA}-list.txt } ; fi") 
+  ${nameModelB}_list=systemfunc ("if [ -f  ${varModel}-${nameModelB}-list.txt ] ; then awk  '{print} NR==${LENGTH}{exit}' ${varModel}-${nameModelB}-list.txt } ; fi") 
+  ${nameObs}_list=systemfunc ("awk  '{print} NR==${LENGTH}{exit}' ${varModel}-${nameObs}-list.txt }") 
+
+  ${nameModelA}_add = addfiles (${nameModelA}_list, "r")   ; note the "s" of addfile
+  ${nameModelB}_add = addfiles (${nameModelB}_list, "r")   
+  ${nameObs}_add = addfiles (${nameObs}_list, "r")   
+
+;---Use the landmask in ${nameModelA} to define land or ocean
+;   Note that 1 is land, 0 is ocean, 2 is ice-covered ocean
+;   variable "masker" is set to fill value over land
+
+  mask_add=addfile("$whereexp/$nameModelB/1p00/dailymean/20120101/land.${nameModelB}.20120101.dailymean.1p00.nc", "r")
+  masker=mask_add->LAND_surface(0,:,:)
+  masker=where(masker.ne.1,masker,masker@_FillValue)   
+
+
+;---Read variables in "join" mode 
+
+  ListSetType (${nameModelA}_add, "join") 
+  ListSetType (${nameModelB}_add, "join") 
+  ListSetType (${nameObs}_add, "join") 
+   
+
+  ${nameModelA}_lat_0=${nameModelA}_add[:]->latitude
+  ${nameModelA}_lon_0=${nameModelA}_add[:]->longitude
+
+  ${nameModelA}_fld = ${nameModelA}_add[:]->${ncvarModel}
+  ${nameModelB}_fld = ${nameModelB}_add[:]->${ncvarModel}
+
+;---Special provision for OSTIA which is written in short format
+
+  if isStrSubset("$nameObs","sst_OSTIA") then
+     ${nameObs}_fld = short2flt(${nameObs}_add[:]->${ncvarObs})
+  else
+
+;---Special provision for TRMM which has a different ordering of dimensions
+
+     if isStrSubset("$nameObs","TRMM") then
+  
+       ${nameObs}_fld_toflip = ${nameObs}_add[:]->${ncvarObs}
+       ${nameObs}_fld = ${nameObs}_fld_toflip(ncl_join|:,time|:,lat|:,lon|:)
+     else
+
+;---No special provision for other OBS
+
+     ${nameObs}_fld = ${nameObs}_add[:]->${ncvarObs}
+     end if 
+  end if
+
+;---Adjust scaling and offset  
+
+  ${nameModelA}_fld=${nameModelA}_fld*${multModel} + 1.*($offsetModel)
+  ${nameModelB}_fld=${nameModelB}_fld*${multModel} + 1.*($offsetModel)
+  ${nameObs}_fld=${nameObs}_fld*${multObs} + 1.*($offsetObs)
+
+;---Apply mask
+
+  maskerbig=conform_dims(dimsizes(${nameModelA}_fld),masker,(/2,3/))
+  if isStrSubset("$mask","landonly") then
+    ${nameObs}_fld=where(ismissing(maskerbig),${nameObs}_fld,${nameObs}_fld@_FillValue)
+    ${nameModelA}_fld=where(ismissing(maskerbig),${nameModelA}_fld,${nameModelA}_fld@_FillValue)
+    ${nameModelB}_fld=where(ismissing(maskerbig),${nameModelB}_fld,${nameModelB}_fld@_FillValue)
+  end if 
+  if isStrSubset("$mask","oceanonly") then
+    ${nameObs}_fld=where(.not.ismissing(maskerbig),${nameObs}_fld,${nameObs}_fld@_FillValue)
+    ${nameModelA}_fld=where(.not.ismissing(maskerbig),${nameModelA}_fld,${nameModelA}_fld@_FillValue)
+    ${nameModelB}_fld=where(.not.ismissing(maskerbig),${nameModelB}_fld,${nameModelB}_fld@_FillValue)
+  end if 
+
+;---Specify dimensions of lat/lon as specified in $domain
+
+  lat_0 = ${nameModelA}_lat_0(0,{${latS}:${latN}})
+  lon_0 = ${nameModelA}_lon_0(0,{${lonW}:${lonE}})
+  nlon=dimsizes(lon_0)
+  nlat=dimsizes(lat_0)
+  dimsObs=getvardims(${nameObs}_fld)
+  dimsModel=getvardims(${nameModelA}_fld)
+
+
+
+; DEFINE PANEL PROPERTIES
+
+
+    panelopts                   = True
+    panelopts@gsnFrame          = False
+    panelopts@gsnPanelRowSpec   = True
+    panelopts@gsnPanelYWhiteSpacePercent = 5
+    panelopts@gsnPanelXWhiteSpacePercent = 5
+
+    title = "$domain $season $varModel vs $nameObs"
+
+    panelopts@gsnPanelMainString = title    ; set main title
+    ;panelopts@gsnPanelLabelBar  = True
+
+
+
+      cmin=1.0*$cmin
+      cmax=1.0*$cmax
+      tmp=dim_avg_n_Wrap(${nameModelA}_fld($s1:$s2,1:2,{${latS}:${latN}},{${lonW}:${lonE}}),(/0,1/))
+      n_obs=num(.not.ismissing(tmp))
+      print(n_obs)
+      print(nlat + " " + nlon + " " + n_obs)
+
+
+     nPanels                     = 5
+     hist                        = new(nPanels,graphic)
+     plot=new((nPanels+1),graphic)
+
+    do week=1,5 
+       d1=(week-1)*7
+       d2=d1+6
+  
+;---Calculate mean maps
+
+  ${nameModelA}_mean=dim_avg_n_Wrap(${nameModelA}_fld($s1:$s2,d1:d2,{${latS}:${latN}},{${lonW}:${lonE}}),(/0,1/))
+  ${nameModelB}_mean=dim_avg_n_Wrap(${nameModelB}_fld($s1:$s2,d1:d2,{${latS}:${latN}},{${lonW}:${lonE}}),(/0,1/))
+  ${nameObs}_mean=dim_avg_n_Wrap(${nameObs}_fld($s1:$s2,d1:d2,{${latS}:${latN}},{${lonW}:${lonE}}),(/0,1/))
+
+;---Calculate bias maps
+
+  ${nameModelA0}_diff=${nameModelA}_mean
+  ${nameModelB0}_diff=${nameModelB}_mean
+
+  ${nameModelA0}_diff=${nameModelA}_mean-${nameObs}_mean
+  ${nameModelB0}_diff=${nameModelB}_mean-${nameObs}_mean
+
+;---Specify units
+
+  ${nameObs}_mean@units="$units"
+  ${nameModelA}_mean@units="$units"
+  ${nameModelB}_mean@units="$units"
+  ${nameModelA0}_diff@units="$units"
+  ${nameModelB0}_diff@units="$units"
+
+;---Prepare bias for histograms
+
+       bias1d=new((/2,dimsizes(ndtooned(${nameModelA0}_diff))/),float)
+       bias1d(0,:)      = ndtooned(${nameModelA0}_diff)
+       bias1d(1,:)      = ndtooned(${nameModelB0}_diff)
+
+      pdfres         = True
+      opt         = True
+      opt@bin_min = cmin
+      opt@bin_max = cmax
+
+       pdfA=pdfx(bias1d(0,:),25,opt)
+       pdfB=pdfx(bias1d(1,:),25,opt)
+
+
+       nVar=2
+       nBin=pdfA@nbins
+
+       xx      = new ( (/nVar, nBin/), typeof(pdfA))
+       xx(0,:) = pdfA@bin_center
+       xx(1,:) = pdfB@bin_center
+
+       yy      = new ( (/nVar, nBin/), typeof(pdfA))
+       yy(0,:) = (/pdfA/)
+       yy(1,:) = (/pdfB/)
+
+  colors=(/"blue","red"/)
+  pdfres@gsnDraw                = False
+  pdfres@gsnFrame               = False
+  pdfres@xyLineThicknessF       = 12
+  pdfres@gsnXRefLine            = 0
+  pdfres@gsnXRefLineThicknessF  = 1.5
+  pdfres@xyLineColors           = colors
+  pdfres@tiYAxisString          = "PDF (%)"
+  pdfres@gsnCenterString        = "PDF: Bias, Week " + week
+  pdfres@trYMaxF = 50
+  
+  plot(week-1)=gsn_csm_xy(wks,xx,yy,pdfres)
+ end do
+
+; THIS IS WHERE THE HISTOGRAMS ARE ACTUALLY DRAWN
+
+
+ panelopts@gsnPanelMainString =  title
+ gsn_panel(wks,plot,(/3,3/),panelopts)
+
+;************************************************
+; set legend resources for simple_legend_ndc
+;************************************************
+    genres                           = True
+    genres@XPosPercent               = 75                      ; orientation on page
+    genres@YPosPercent               = 35
+    genres@ItemSpacePercent          = 3
+    textres                          = True
+    textres@lgLabels                 = (/"$nameModelA", "$nameModelB"/)
+    textres@lgPerimOn                = False                   ; no perimeter
+    textres@lgItemCount              = 2                       ; how many
+    lineres                          = True
+    lineres@lgLineLabelFontHeightF   = 0.015                   ; font height
+    lineres@lgDashIndexes            = (/0,1/)             ; line patterns
+    lineres@lgLineColors             = colors
+    lineres@lgLineThicknesses        = 12                     ; line thicknesses
+
+  simple_legend_ndc(wks, genres, lineres, textres)
+  frame(wks)
+
+
+EOF
+
+ncl pdf_${season}.ncl
+
+
+

--- a/ATM/run_checking/WithoutObs/drive_mapnoobs.sh
+++ b/ATM/run_checking/WithoutObs/drive_mapnoobs.sh
@@ -1,62 +1,64 @@
 #!/bin/bash -l
-#SBATCH -A marine-cpu        # -A specifies the account
+#SBATCH -A fv3-cpu        # -A specifies the account
 #SBATCH -n 1                 # -n specifies the number of tasks (cores) (-N would be for number of yesdes) 
 #SBATCH --exclusive          # exclusive use of node - hoggy but OK
 #SBATCH -q debug             # -q specifies the queue; debug has a 30 min limit, but the default walltime is only 5min, to change, see below:
 #SBATCH -t 30                # -t specifies walltime in minutes; if in debug, cannot be more than 30
 
+module load intel
+module load ncl
 
 # This is a tiny little package that compares two sets of (exp1 and exp2) for a chosen variable, domain, season
 # The data is expected to be in /scratch3/NCEPDEV/marine/noscrub/Lydia.B.Stefanova/Models/$exp/1p00/dailymean/          
     
-    hardcopy=no           # yes | no
-
-    #exp1=ufs_p4
-    #exp2=P4p0_uncoupled_GFS
-    #exp2=P4p0_uncoupled_GSL
-
-    exp1=ufs_b31
-
-    exp1=ufs_p4
-    exp2=ufs_p5
-
-    #exp1=ufs_b1
-    #exp2=ufs_b2
+    hardcopy=yes           # yes | no
 
 
-    #exp2=ufs_p4_pre                                                          
-    #exp2=heratest
+    exp1=ufs_p5
+    exp2=ufs_p6
+
     
     whereexp=$noscrub/Models/
+    res=Orig
+    res=1p00
+    nplots=1
 
 
 # The script is  prepared to handle variables on the list below 
-    oknames=(land tmpsfc tmp2m t2min t2max ulwrftoa dlwrf dswrf ulwrf uswrf prate pwat icetk icec cloudbdry cloudlow cloudmid cloudhi snow weasd snod lhtfl shtfl pres u10 v10 uflx vflx soilm02m sfcr)
+    oknames=(land tmpsfc tmp2m t2min t2max ulwrftoa dlwrf dswrf ulwrf uswrf prate pwat icetk icec cloudbdry cloudlow cloudmid cloudhi snow weasd snod lhtfl shtfl pres u10 v10 uflx vflx soilm02m sfcr speed spfh2m u850 v850 z500 u200 v200) 
 
-    #for varname in prate ulwrftoa cloudbdry cloudmid cloudlow cloudhi ; do
-    # for varname in pwat prec soilm02m sfcr ; do
-     for varname in icec icetk; do
+    # for varname in snod pres cloudlow cloudbdry cloudmid cloudhi dswrf uswrf dlwrf ulwrf ; do 
+    # for varname in tmpsfc tmp2m t2min t2max ulwrftoa pwat icec icetk lhtfl shtfl prate; do
 
-    # for varname in shtfl lhtfl ; do
-    #for varname in tmp2m tmpsfc prate pwat soilm02m sfcr ulwrftoa ulwrf uswrf dlwrf dswrf cloudbdry cloudlow cloudmid cloudhi shtfl lhtfl ; do
-    #for varname in pres dlwrf dswrf ulwrf uswrf cloudbdry cloudlow cloudmid cloudhi shtfl lhtfl; do
-       # for varname in dswrf uswrf ulwrftoa cloudlow cloudmid cloudhi ; do 
+    #for varname in cloudhi icec pwat ulwrf cloudlow icetk tmp2m uswrf cloudlow icetk tmp2m uswrf dlwrf tmpsfc  dswrf prate ulwrftoa ; do
+    #for varname in tmpsfc dswrf prate ulwrftoa ; do
+    # for varname in cloudhi cloudlow cloudmid cloudbdry ; do
+    # for varname in soilm02m spfh2m cloudbdry cloudlow ; do
+    # for varname in tmp2m tmpsfc ulwrftoa cloudbdry cloudlow cloudmid cloudhi dswrf prate u10 pres ; do
+     #for varname in u200 z500 u850 ; do
+      for varname in pwat ; do
+
         case "${oknames[@]}" in 
                 *"$varname"*)  ;; 
                 *)
              echo "Exiting. To continue, please correct: unknown variable ---> $varname <---"
              exit
         esac
-       for domain in NH ; do
-            for season in JJA  ; do
-                echo "Attempting $domain $season $varname "
-                bash  map_compare_noobs_polar.sh varModel=$varname domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp1 nameModelB=$exp2 d1=20 d2=34 whereexp=$whereexp
-            done
-        done
+       #for domain in NH ; do
+       #     for season in DJF  ; do
+       #         echo "Attempting $domain $season $varname "
+       #         bash  map_compare_noobs_polar.sh varModel=$varname domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp1 nameModelB=$exp2 d1=0 d2=34 whereexp=$whereexp
+       #     done
+       # done
         for domain in Global  ; do    
-            for season in JJA ; do
+            #for season in AllAvailable MAM JJA SON DJF; do
+            for season in AllAvailable ; do
                 echo "Attempting $domain $season $varname "
-                bash  map_compare_noobs.sh varModel=$varname domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp1 nameModelB=$exp2 d1=0 d2=0 whereexp=$whereexp
+                #bash  map_compare_noobs.sh varModel=$varname domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp1 nameModelB=$exp2 d1=0 d2=34 whereexp=$whereexp nplots=$nplots res=$res 
+                bash  map_compare_noobs.sh varModel=$varname domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp1 nameModelB=$exp2 d1=0 d2=6 whereexp=$whereexp nplots=$nplots res=$res
+                #bash  map_compare_noobs.sh varModel=$varname domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp1 nameModelB=$exp2 d1=7 d2=13 whereexp=$whereexp nplots=$nplots res=$res 
+                #bash  map_compare_noobs.sh varModel=$varname domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp1 nameModelB=$exp2 d1=14 d2=20 whereexp=$whereexp nplots=$nplots res=$res 
+                bash  map_compare_noobs.sh varModel=$varname domain=$domain hardcopy=$hardcopy season=$season nameModelA=$exp1 nameModelB=$exp2 d1=14 d2=27 whereexp=$whereexp nplots=$nplots res=$res 
             done
         done
     done

--- a/ATM/run_checking/WithoutObs/map_compare_noobs.sh
+++ b/ATM/run_checking/WithoutObs/map_compare_noobs.sh
@@ -22,8 +22,13 @@ do
             nameModelB) nameModelB=${VALUE} ;;
             d1)     d1=${VALUE};;
             d2)     d2=${VALUE};;
+            mask)   mask=${VALUE:-"nomask"};;
+            nplots) nplots=${VALUE:-3};;
+            res)    res=${VALUE:-1p00};;
             *)
     esac
+
+    echo $nplots
 
 
 done
@@ -42,104 +47,123 @@ esac
 
 
 nameModelBA=${nameModelB}_minus_${nameModelA}
+       if [ "$varModel" == "u200" ] ; then
+          ncvarModel="UGRD_200mb"; multModel=1; offsetModel=0.; units="m/s"
+       fi
+       if [ "$varModel" == "v200" ] ; then
+          ncvarModel="VGRD_200mb"; multModel=1; offsetModel=0.; units="m/s"
+       fi
+       if [ "$varModel" == "u850" ] ; then
+          ncvarModel="UGRD_850mb"; multModel=1; offsetModel=0.; units="m/s"
+       fi
+       if [ "$varModel" == "v850" ] ; then
+          ncvarModel="VGRD_850mb"; multModel=1; offsetModel=0.; units="m/s"
+       fi
+       if [ "$varModel" == "z500" ] ; then
+          ncvarModel="HGT_500mb"; multModel=1; offsetModel=0.; units="m"
+       fi
        if [ "$varModel" == "icec" ] ; then
-          ncvarModel="ICEC_surface"; multModel=1; offsetModel=0.; units="%"; mask="oceanonly"
+          ncvarModel="ICEC_surface"; multModel=1; offsetModel=0.; units="%"
        fi
        if [ "$varModel" == "sfcr" ] ; then
-          ncvarModel="SFCR_surface"; multModel=1; offsetModel=0.; units="m"; mask="oceanonly"
+          ncvarModel="SFCR_surface"; multModel=1; offsetModel=0.; units="m"
        fi
        if [ "$varModel" == "soilm02m" ] ; then
-          ncvarModel="SOIL_M_0M2mbelowground"; multModel=1; offsetModel=0.; units="kg/m^2"; mask="landonly"
+          ncvarModel="SOIL_M_0M2mbelowground"; multModel=1; offsetModel=0.; units="kg/m^3"
        fi
        if [ "$varModel" == "pres" ] ; then
-          ncvarModel="PRES_surface"; multModel=0.01; offsetModel=0.; units="mb"; mask="nomask"
+          ncvarModel="PRES_surface"; multModel=0.01; offsetModel=0.; units="mb"
        fi
        if [ "$varModel" == "u10" ] ; then
-          ncvarModel="UGRD_10maboveground"; multModel=1.; offsetModel=0.; units="m/s"; mask="nomask"
+          ncvarModel="UGRD_10maboveground"; multModel=1.; offsetModel=0.; units="m/s"
        fi
        if [ "$varModel" == "v10" ] ; then
-          ncvarModel="VGRD_10maboveground"; multModel=1.; offsetModel=0.; units="m/s"; mask="nomask"
+          ncvarModel="VGRD_10maboveground"; multModel=1.; offsetModel=0.; units="m/s"
+       fi
+       if [ "$varModel" == "speed" ] ; then
+          ncvarModel="spd10"; multModel=1.; offsetModel=0.; units="m/s"
        fi
        if [ "$varModel" == "t2max" ] ; then
-          ncvarModel="TMAX_2maboveground"; multModel=1.; offsetModel=0.; units="deg K"; mask="landonly"
+          ncvarModel="TMAX_2maboveground"; multModel=1.; offsetModel=0.; units="deg K"
        fi
        if [ "$varModel" == "t2min" ] ; then
-          ncvarModel="TMIN_2maboveground"; multModel=1.; offsetModel=0.; units="deg K";mask="landonly"
+          ncvarModel="TMIN_2maboveground"; multModel=1.; offsetModel=0.; units="deg K"
        fi
        if [ "$varModel" == "tmp2m" ] ; then
-          ncvarModel="TMP_2maboveground"; multModel=1.; offsetModel=0.; units="deg K";mask="landonly"
-          ncvarModel="TMP_2maboveground"; multModel=1.; offsetModel=0.; units="deg K";mask="nomask"
+          ncvarModel="TMP_2maboveground"; multModel=1.; offsetModel=0.; units="deg K"
+       fi
+       if [ "$varModel" == "spfh2m" ] ; then
+          ncvarModel="SPFH_2maboveground"; multModel=1000.; offsetModel=0.; units="g/kg"
        fi
        if [ "$varModel" == "tmpsfc" ] ; then
-          ncvarModel="TMP_surface"; multModel=1.; offsetModel=0.; units="deg K";mask="oceanonly"
-          ncvarModel="TMP_surface"; multModel=1.; offsetModel=0.; units="deg K";mask="nomask"
+          ncvarModel="TMP_surface"; multModel=1.; offsetModel=0.; units="deg K"
+          ncvarModel="TMP_surface"; multModel=1.; offsetModel=0.; units="deg K"
        fi
        if [ "$varModel" == "shtfl" ] ; then
-          ncvarModel="SHTFL_surface"; multModel=1.; offsetModel=0.; units="W/m^2"; mask="nomask"
+          ncvarModel="SHTFL_surface"; multModel=1.; offsetModel=0.; units="W/m^2"
        fi
        if [ "$varModel" == "prate" ] ; then
-          ncvarModel="PRATE_surface"; multModel=86400.; offsetModel=0.; units="mm/day"; mask="nomask"
+          ncvarModel="PRATE_surface"; multModel=86400.; offsetModel=0.; units="mm/day"
        fi
        if [ "$varModel" == "lhtfl" ] ; then
-          ncvarModel="LHTFL_surface"; multModel=0.03456; offsetModel=0.; units="mm/day"; mask="nomask"
+          ncvarModel="LHTFL_surface"; multModel=0.03456; offsetModel=0.; units="mm/day"
        fi
        if [ "$varModel" == "pwat" ] ; then
-           ncvarModel="PWAT_entireatmosphere_consideredasasinglelayer_"; multModel=1.; offsetModel=0.; units="kg/m^2"; mask="nomask"
+           ncvarModel="PWAT_entireatmosphere_consideredasasinglelayer_"; multModel=1.; offsetModel=0.; units="kg/m^2"
        fi
        if [ "$varModel" == "cloudhi" ] ; then
-           ncvarModel="TCDC_highcloudlayer"; multModel=1.; offsetModel=0.; units="percent"; mask="nomask"
+           ncvarModel="TCDC_highcloudlayer"; multModel=1.; offsetModel=0.; units="percent"
        fi
        if [ "$varModel" == "cloudmid" ] ; then
-        ncvarModel="TCDC_middlecloudlayer"; multModel=1.; offsetModel=0.; units="percent"; mask="nomask"
+        ncvarModel="TCDC_middlecloudlayer"; multModel=1.; offsetModel=0.; units="percent"
        fi
        if [ "$varModel" == "cloudlow" ] ; then
-           ncvarModel="TCDC_lowcloudlayer"; multModel=1.; offsetModel=0.; units="percent"; mask="nomask"
+           ncvarModel="TCDC_lowcloudlayer"; multModel=1.; offsetModel=0.; units="percent"
        fi
        if [ "$varModel" == "cloudbdry" ] ; then
-           ncvarModel="TCDC_boundarylayercloudlayer"; multModel=1.; offsetModel=0.; units="percent"; mask="nomask"
+           ncvarModel="TCDC_boundarylayercloudlayer"; multModel=1.; offsetModel=0.; units="percent"
        fi
        if [ "$varModel" == "ulwrftoa" ] ; then
-           ncvarModel="ULWRF_topofatmosphere"; multModel=1.; offsetModel=0.; units="W/m^2"; mask="nomask"
+           ncvarModel="ULWRF_topofatmosphere"; multModel=1.; offsetModel=0.; units="W/m^2"
        fi
        if [ "$varModel" == "dlwrf" ] ; then
-           ncvarModel="DLWRF_surface"; multModel=1.; offsetModel=0.; units="W/m^2"; mask="nomask"
+           ncvarModel="DLWRF_surface"; multModel=1.; offsetModel=0.; units="W/m^2"
        fi
        if [ "$varModel" == "dswrf" ] ; then
-           ncvarModel="DSWRF_surface"; multModel=1.; offsetModel=0.; units="W/m^2"; mask="nomask"
+           ncvarModel="DSWRF_surface"; multModel=1.; offsetModel=0.; units="W/m^2"
        fi
        if [ "$varModel" == "uswrf" ] ; then
-           ncvarModel="USWRF_surface"; multModel=1.; offsetModel=0.; units="W/m^2"; mask="nomask"
+           ncvarModel="USWRF_surface"; multModel=1.; offsetModel=0.; units="W/m^2"
        fi
        if [ "$varModel" == "ulwrf" ] ; then
-           ncvarModel="ULWRF_surface"; multModel=1.; offsetModel=0.; units="W/m^2"; mask="nomask"
+           ncvarModel="ULWRF_surface"; multModel=1.; offsetModel=0.; units="W/m^2"
        fi
        if [ "$varModel" == "snow" ] ; then
-           ncvarModel="SNOWC_surface"; multModel=1.; offsetModel=0.; units="percent"; mask="nomask"
+           ncvarModel="SNOWC_surface"; multModel=1.; offsetModel=0.; units="percent"
        fi
        if [ "$varModel" == "snod" ] ; then
-           ncvarModel="SNOD_surface"; multModel=1.; offsetModel=0.; units="m"; mask="nomask"
+           ncvarModel="SNOD_surface"; multModel=1.; offsetModel=0.; units="m"
        fi
 
-       mask="oceanonly"
        rm -f ${varModel}-${nameModelA}-list.txt ${varModel}-${nameModelB}-list.txt    # clean up from last time
 
        LENGTH=0
        pass=0
        for yyyy in {2011..2018..1} ; do
-       for mm1 in {1..12..3} ; do
+       for mm1 in {1..12..1} ; do
        for dd1 in {1..15..1400} ; do
            mm=$(printf "%02d" $mm1)
            dd=$(printf "%02d" $dd1)
            tag=$yyyy$mm${dd}
-           if [ -f $whereexp/$nameModelA/1p00/dailymean/${tag}/${varModel}.${nameModelA}.${tag}.dailymean.1p00.nc ] ; then
-              if [ -f $whereexp/$nameModelB/1p00/dailymean/${tag}/${varModel}.${nameModelB}.${tag}.dailymean.1p00.nc ] ; then
+           if [ -f $whereexp/$nameModelA/${res}/dailymean/${tag}/${varModel}.${nameModelA}.${tag}.dailymean.${res}.nc ] ; then
+              if [ -f $whereexp/$nameModelB/${res}/dailymean/${tag}/${varModel}.${nameModelB}.${tag}.dailymean.${res}.nc ] ; then
 
                  case "${season}" in
                       *"DJF"*)
                           if [ $mm1 -ge 12 ] || [ $mm1 -le 2 ] ; then
                              for nameModel in $nameModelA $nameModelB ; do
-                                 pathModel="$whereexp/$nameModel/1p00/dailymean"
-                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.1p00.nc >> ${varModel}-${nameModel}-list.txt
+                                 pathModel="$whereexp/$nameModel/${res}/dailymean"
+                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.${res}.nc >> ${varModel}-${nameModel}-list.txt
                              done
                                  LENGTH="$(($LENGTH+1))"                       # How many ICs are considered
                           fi
@@ -147,8 +171,8 @@ nameModelBA=${nameModelB}_minus_${nameModelA}
                       *"MAM"*)
                           if [ $mm1 -ge 3 ] && [ $mm1 -le 5 ] ; then
                              for nameModel in $nameModelA $nameModelB ; do
-                                 pathModel="$whereexp/$nameModel/1p00/dailymean"
-                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.1p00.nc >> ${varModel}-${nameModel}-list.txt
+                                 pathModel="$whereexp/$nameModel/${res}/dailymean"
+                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.${res}.nc >> ${varModel}-${nameModel}-list.txt
                              done
                                  LENGTH="$(($LENGTH+1))"                       # How many ICs are considered
                           fi
@@ -156,8 +180,8 @@ nameModelBA=${nameModelB}_minus_${nameModelA}
                       *"JJA"*)
                           if [ $mm1 -ge 6 ] && [ $mm1 -le 8 ] ; then
                              for nameModel in $nameModelA $nameModelB ; do
-                                 pathModel="$whereexp/$nameModel/1p00/dailymean"
-                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.1p00.nc >> ${varModel}-${nameModel}-list.txt
+                                 pathModel="$whereexp/$nameModel/${res}/dailymean"
+                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.${res}.nc >> ${varModel}-${nameModel}-list.txt
                              done
                                  LENGTH="$(($LENGTH+1))"                       # How many ICs are considered
                           fi
@@ -165,16 +189,16 @@ nameModelBA=${nameModelB}_minus_${nameModelA}
                       *"SON"*)
                           if [ $mm1 -ge 9 ] && [ $mm1 -le 11 ] ; then
                              for nameModel in $nameModelA $nameModelB ; do
-                                 pathModel="$whereexp/$nameModel/1p00/dailymean"
-                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.1p00.nc >> ${varModel}-${nameModel}-list.txt
+                                 pathModel="$whereexp/$nameModel/${res}/dailymean"
+                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.${res}.nc >> ${varModel}-${nameModel}-list.txt
                              done
                                  LENGTH="$(($LENGTH+1))"                       # How many ICs are considered
                           fi
                       ;;
                       *"AllAvailable"*)
                              for nameModel in $nameModelA $nameModelB ; do
-                                 pathModel="$whereexp/$nameModel/1p00/dailymean"
-                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.1p00.nc >> ${varModel}-${nameModel}-list.txt
+                                 pathModel="$whereexp/$nameModel/${res}/dailymean"
+                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.${res}.nc >> ${varModel}-${nameModel}-list.txt
                              done
                                  LENGTH="$(($LENGTH+1))"                       # How many ICs are considered
                       ;;
@@ -223,7 +247,7 @@ cat << EOF > $nclscript
      wks_type@wkHeight            = 800
   end if 
 
-  wks                          = gsn_open_wks(wks_type,"${varModel}.${nameModelB}.vs.${nameModelA}.${season}.${startname}.d${d1p1}-d${d2p1}.$domain")
+  wks                          = gsn_open_wks(wks_type,"diffmaps.${varModel}.${nameModelB}.vs.${nameModelA}.${season}.${startname}.d${d1p1}-d${d2p1}.$domain")
 
   latStart=${latS}
   latEnd=${latN}
@@ -242,7 +266,7 @@ cat << EOF > $nclscript
   ${nameModelA}_add = addfiles (${nameModelA}_list, "r")   ; note the "s" of addfile
   ${nameModelB}_add = addfiles (${nameModelB}_list, "r")   
 
-  maskMod=addfile("$whereexp/${nameModelA}/1p00/dailymean/20120101/land.${nameModelA}.20120101.dailymean.1p00.nc", "r")
+  maskMod=addfile("$whereexp/${nameModelA}/${res}/dailymean/20120101/land.${nameModelA}.20120101.dailymean.${res}.nc", "r")
   masker=maskMod->LAND_surface(0,{${latS}:${latN}},{${lonW}:${lonE}})
   masker=where(masker.ne.1,masker,masker@_FillValue)
 
@@ -257,8 +281,13 @@ cat << EOF > $nclscript
   ${nameModelA}_lat_0=${nameModelA}_add[:]->latitude
   ${nameModelA}_lon_0=${nameModelA}_add[:]->longitude
 
-  ${nameModelA}_fld = ${nameModelA}_add[:]->${ncvarModel}
-  ${nameModelB}_fld = ${nameModelB}_add[:]->${ncvarModel}
+
+  nameA=getfilevarnames(${nameModelA}_add[0])
+  nameB=getfilevarnames(${nameModelB}_add[0])
+
+  ${nameModelA}_fld = ${nameModelA}_add[:]->\$nameA(4)\$
+  ${nameModelB}_fld = ${nameModelB}_add[:]->\$nameB(4)\$
+
 
 ;--- Provision for one of the models being a shorter run 
 
@@ -370,10 +399,10 @@ cat << EOF > $nclscript
   ${nameModelB}_mean@long_name=${nameModelB}_mean@long_name + " " + "${nameModelB}" +"; mean=" + ${nameModelB}_aave
   ;${nameModelBA}_diff@long_name="Difference" +"; mean=" + ${nameModelBA}_aave + "; rmsd=" + ${nameModelBA}_rmsd
   ;${nameModelBA}_diff@long_name="Difference" +"; mean=" + ${nameModelBA}_aave 
-  ${nameModelBA}_diff@long_name="Difference" +"; mean=" + ${nameModelBA}_aave + "; min=" + amin + "; max=" + amax
+  ${nameModelBA}_diff@long_name="${nameModelB} minus ${nameModelA}"+"; mean=" + ${nameModelBA}_aave + "; min=" + amin + "; max=" + amax
   ratio@long_name="Percent Change"
 
-  plot=new(1,graphic)
+  plot=new(3,graphic)
 
   res                     = True
   if (isStrSubset("$domain","CONUS").or.isStrSubset("$domain","NAM").or.isStrSubset("$domain","IndoChina")) then
@@ -407,7 +436,49 @@ cat << EOF > $nclscript
   res1=res
   res2=res
 
+  if (isStrSubset("{$varModel}","200")) then
+      res0@cnMinLevelValF  = -40.
+      res0@cnMaxLevelValF  = 40.
+      res0@cnLevelSpacingF  = 5.
+
+      res1@cnMinLevelValF  = -5.
+      res1@cnMaxLevelValF  = 5.
+      res1@cnLevelSpacingF  = 0.5
+
+      res2=res1
+
+  end if
+  if (isStrSubset("{$varModel}","850")) then
+      res0@cnMinLevelValF  = -12.
+      res0@cnMaxLevelValF  = 12.
+      res0@cnLevelSpacingF  = 2.
+
+      res1@cnMinLevelValF  = -3.
+      res1@cnMaxLevelValF  = 3.
+      res1@cnLevelSpacingF  = 0.2
+
+      res2=res1
+
+  end if
+  if (isStrSubset("{$varModel}","500")) then
+      res0@cnMinLevelValF  = 5000.
+      res0@cnMaxLevelValF  = 5800.
+      res0@cnLevelSpacingF  = 100.
+
+      res1@cnMinLevelValF  = -50.
+      res1@cnMaxLevelValF  = 50.
+      res1@cnLevelSpacingF  = 5
+
+      res2=res1
+
+  end if
+  
+
   if (isStrSubset("{$varModel}","sfcr")) then
+       res0@cnFillPalette        = "temp_diff_18lev"
+       res0@cnLevelSelectionMode = "ExplicitLevels"   ; set explicit contour levels
+       res0@cnLevels             = (/ 1.e-5,2.e-5,3.e-5,4.e-5,5e-5,6e-5,7e-5,8e-5,9e-5,1e-4/)   ; set levels
+
       res1@cnFillPalette        = "temp_diff_18lev"
       res1@cnFillPalette        = "BlueDarkRed18"
       res1@cnLevelSelectionMode = "ExplicitLevels"   ; set explicit contour levels
@@ -418,20 +489,33 @@ cat << EOF > $nclscript
       res1@cnLevels             = (/   -1e-2,-1e-3,-1e-4,-1e-5,-1e-8,1e-8,  1e-5, 1e-4, 1e-3,1e-2/)   ; set levels
       res1@lbLabelAutoStride = False
       res1@lbLabelAngleF=90
+
+       res2@cnLevelSelectionMode = "ExplicitLevels"   ; set explicit contour levels
+       res2@cnLevels             = (/ -40., -20., -10.,-5.,-2., 2. ,5. ,10. ,20. , 40./)   ; set levels
+      res3=res0
+      res3@cnLevels :=(/-1.e-4,-8e-5,-6e-5,-4e-5,-2e-5,2.e-5,4e-5,6e-5,8e-5,1e-4/)
   end if
 
   if (isStrSubset("{$varModel}","cloud")) then
        cmap=read_colormap_file("MPL_gnuplot")
        cmap = cmap(::-1,:)
-       res0@cnFillPalette = cmap
+;       res0@cnFillPalette = cmap
+
+;       res0@cnFillPalette="precip3_16lev"
+       res0@cnFillPalette="CBR_wet"
+
+
        res0@cnMinLevelValF  = 10.
        res0@cnMaxLevelValF  = 90.
        res0@cnLevelSpacingF  = 10.
 
-       res1@cnFillPalette        = "sunshine_diff_12lev"
+;       res1@cnFillPalette        = "sunshine_diff_12lev"
+;       res1@cnFillPalette="precip3_16lev"
+       res1@cnFillPalette="precip_diff_12lev"
        res1@cnLevelSelectionMode = "ExplicitLevels"   ; set explicit contour levels
        res1@cnLevels             = (/ -40., -20., -10.,-5.,-2., 2. ,5. ,10. ,20. , 40./)   ; set levels
        res1@cnFillColors         = (/ 11,  10,   9,    8,   7,  6,  5,  4,  3,    2,  1/)  ; set the colors to be used
+       res1@cnFillColors         = (/ 1,  2,   3,    4,  5,  6,  7,  8,  9,    10,  11/)  ; set the colors to be used
 
 
        res2=res1
@@ -485,18 +569,28 @@ cat << EOF > $nclscript
 
 
 
-  if (isStrSubset("{$varModel}","10")) then
+  if (isStrSubset("{$varModel}","speed")) then
+      res0@cnMinLevelValF  = 0.
+      res0@cnMaxLevelValF  = 2.
+      res0@cnLevelSpacingF  = 0.2
+
+      res3=res0
+      res3@cnMinLevelValF  = -0.2
+      res3@cnMaxLevelValF  = 0.2
+      res3@cnLevelSpacingF  = 0.05
+  end if
+
+  if (isStrSubset("{$varModel}","u10")) then
       res0@cnMinLevelValF  = -10.
       res0@cnMaxLevelValF  = 10.
-      res0@cnLevelSpacingF  = 2.
+      res0@cnLevelSpacingF  = 1.
 
-      res1@cnFillPalette        = "temp_diff_18lev"
-      res1@cnLevelSelectionMode = "ExplicitLevels"   ; set explicit contour levels
-      res1@cnLevels             = (/ -4., -3., -2.,-1.,-0.5, -0.2, -0.1, 0.1, 0.2, 0.5 ,1. ,2., 3., 4./)   ; set levels
+      res1@cnMinLevelValF  = -2.
+      res1@cnMaxLevelValF  = 2.
+      res1@cnLevelSpacingF  = 0.1
 
-      res2@cnFillPalette        = "temp_diff_18lev"
-      res2@cnLevelSelectionMode = "ExplicitLevels"   ; set explicit contour levels
-      res2@cnLevels             = (/ -40., -20., -10.,-5.,-2., 2. ,5. ,10. ,20. , 40./)   ; set levels
+      res2=res1
+
   end if
   if (isStrSubset("{$varModel}","pres")) then
       res0@cnMinLevelValF  = 500.
@@ -510,6 +604,17 @@ cat << EOF > $nclscript
       res2@cnFillPalette        = "temp_diff_18lev"
       res2@cnLevelSelectionMode = "ExplicitLevels"   ; set explicit contour levels
       res2@cnLevels             = (/ -40., -20., -10.,-5.,-2., 2. ,5. ,10. ,20. , 40./)   ; set levels
+  end if
+  if (isStrSubset("{$varModel}","spfh2m")) then
+       res0@cnFillPalette="CBR_wet"
+       res0@cnMinLevelValF  = 0.
+       res0@cnMaxLevelValF  = 20.
+       res0@cnLevelSpacingF  = 2.
+
+       res1@cnFillPalette="precip_diff_12lev"
+       res1@cnLevelSelectionMode = "ExplicitLevels"   ; set explicit contour levels
+       res1@cnLevels             = (/ -1., -0.8, -0.6,-0.4,-0.2, 0.2 ,0.4 ,0.6 ,0.8 , 1./)   ; set levels
+       res1@cnFillColors         = (/ 1,  2,   3,    4,  5,  6,  7,  8,  9,    10,  11/)  ; set the colors to be used
   end if
   if (isStrSubset("{$varModel}","tmpsfc").or.isStrSubset("{$varModel}","tmp2m")) then
       res0@cnMinLevelValF  = 220.
@@ -624,16 +729,10 @@ cat << EOF > $nclscript
        res2@cnLevels             = (/ -40., -20., -10.,-5.,-2., 2. ,5. ,10. ,20. , 40./)   ; set levels
   end if 
 
-  res1@mpGeophysicalLineThicknessF=0.3
+  ;res1@mpGeophysicalLineThicknessF=0.3
 
-  ;plot(0) = gsn_csm_contour_map(wks,${nameModelA}_mean,res0)
-  ;plot(2) = gsn_csm_contour_map(wks,${nameModelB}_mean,res0)
-  ;plot(3) = gsn_csm_contour_map(wks,${nameModelBA}_diff,res1)
-  ;if (isStrSubset("${varModel}","pres").or.isStrSubset("${varModel}","10").or.isStrSubset("${varModel}","tmp").or.isStrSubset("${varModel}","2m")) then
-  ;else
-  ;plot(3) = gsn_csm_contour_map(wks,ratio,res2)
-  ;end if
-  plot(0) = gsn_csm_contour_map(wks,${nameModelBA}_diff,res1)
+
+
 
 
   panelopts                   = True
@@ -647,7 +746,29 @@ cat << EOF > $nclscript
   panelopts@gsnPanelYWhiteSpacePercent = 0
   panelopts@gsnPanelXWhiteSpacePercent = 5
   panelopts@amJust   = "TopLeft"
-  gsn_panel(wks,plot,(/1/),panelopts)
+
+  ;plot(3) = gsn_csm_contour_map(wks,${nameModelBA}_diff,res1)
+  ;if (isStrSubset("${varModel}","pres").or.isStrSubset("${varModel}","10").or.isStrSubset("${varModel}","tmp").or.isStrSubset("${varModel}","2m")) then
+  ;else
+  ;plot(3) = gsn_csm_contour_map(wks,ratio,res2)
+  ;end if
+
+  if ($nplots.eq.3) then
+     plot(0) = gsn_csm_contour_map(wks,${nameModelA}_mean,res0)
+     plot(1) = gsn_csm_contour_map(wks,${nameModelB}_mean,res0)
+     plot(2) = gsn_csm_contour_map(wks,${nameModelBA}_diff,res1)
+     gsn_panel(wks,plot,(/1,1,1/),panelopts)
+  end if
+  if ($nplots.eq.2) then
+     plot(0) = gsn_csm_contour_map(wks,${nameModelB}_mean,res0)
+     plot(1) = gsn_csm_contour_map(wks,${nameModelBA}_diff,res1)
+     ;plot(1) = gsn_csm_contour_map(wks,ratio,res2)
+     gsn_panel(wks,plot,(/1,1/),panelopts)
+  end if
+  if ($nplots.eq.1) then
+     plot(0) = gsn_csm_contour_map(wks,${nameModelBA}_diff,res1)
+     gsn_panel(wks,plot,(/1/),panelopts)
+  end if
 
 EOF
 

--- a/ATM/run_checking/WithoutObs/map_compare_noobs_polar.sh
+++ b/ATM/run_checking/WithoutObs/map_compare_noobs_polar.sh
@@ -22,6 +22,8 @@ do
             nameModelB) nameModelB=${VALUE} ;;
             d1) d1=${VALUE} ;;
             d2) d2=${VALUE} ;;
+            nplots) nplots=${VALUE:-3} ;;
+            res) res=${VALUE:-1p00} ;;
             *)
     esac
 
@@ -35,8 +37,8 @@ case "$domain" in
     "Global50") latS="-50"; latN="50" ;  lonW="0" ; lonE="360" ;;
     "CONUS") latS="25"; latN="60" ;  lonW="210" ; lonE="300" ;;
     "NAM") latS="0"; latN="90" ;  lonW="180" ; lonE="360" ;;
-    "NH") latS="50"; latN="90" ;  lonW="0" ; lonE="360" ;;
-    "SH") latS="-90"; latN="-50" ;  lonW="0" ; lonE="360" ;;
+    "NH") latS="40"; latN="90" ;  lonW="0" ; lonE="360" ;;
+    "SH") latS="-90"; latN="-40" ;  lonW="0" ; lonE="360" ;;
     *)
 esac
 
@@ -119,26 +121,29 @@ nameModelBA=${nameModelB}_minus_${nameModelA}
        if [ "$varModel" == "icec" ] ; then
            ncvarModel="ICEC_surface"; multModel=100.; offsetModel=0.; units="percent"; mask="nomask"
        fi
+    
+       mask="oceanonly"
+       mask="nomask"
 
        rm -f ${varModel}-${nameModelA}-list.txt ${varModel}-${nameModelB}-list.txt    # clean up from last time
 
        LENGTH=0
        pass=0
        for yyyy in {2011..2018..1} ; do
-       for mm1 in {1..12..3} ; do
-       for dd1 in {1..15..14} ; do
+       for mm1 in {1..12..1} ; do
+       for dd1 in {1..15..140} ; do
            mm=$(printf "%02d" $mm1)
            dd=$(printf "%02d" $dd1)
            tag=$yyyy$mm${dd}
-           if [ -f $whereexp/$nameModelA/1p00/dailymean/${tag}/${varModel}.${nameModelA}.${tag}.dailymean.1p00.nc ] ; then
-              if [ -f $whereexp/$nameModelB/1p00/dailymean/${tag}/${varModel}.${nameModelB}.${tag}.dailymean.1p00.nc ] ; then
+           if [ -f $whereexp/$nameModelA/${res}/dailymean/${tag}/${varModel}.${nameModelA}.${tag}.dailymean.${res}.nc ] ; then
+              if [ -f $whereexp/$nameModelB/${res}/dailymean/${tag}/${varModel}.${nameModelB}.${tag}.dailymean.${res}.nc ] ; then
 
                  case "${season}" in
                       *"DJF"*)
                           if [ $mm1 -ge 12 ] || [ $mm1 -le 2 ] ; then
                              for nameModel in $nameModelA $nameModelB ; do
-                                 pathModel="$whereexp/$nameModel/1p00/dailymean"
-                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.1p00.nc >> ${varModel}-${nameModel}-list.txt
+                                 pathModel="$whereexp/$nameModel/${res}/dailymean"
+                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.${res}.nc >> ${varModel}-${nameModel}-list.txt
                              done
                                  LENGTH="$(($LENGTH+1))"                       # How many ICs are considered
                           fi
@@ -146,8 +151,8 @@ nameModelBA=${nameModelB}_minus_${nameModelA}
                       *"MAM"*)
                           if [ $mm1 -ge 3 ] && [ $mm1 -le 5 ] ; then
                              for nameModel in $nameModelA $nameModelB ; do
-                                 pathModel="$whereexp/$nameModel/1p00/dailymean"
-                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.1p00.nc >> ${varModel}-${nameModel}-list.txt
+                                 pathModel="$whereexp/$nameModel/${res}/dailymean"
+                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.${res}.nc >> ${varModel}-${nameModel}-list.txt
                              done
                                  LENGTH="$(($LENGTH+1))"                       # How many ICs are considered
                           fi
@@ -155,8 +160,8 @@ nameModelBA=${nameModelB}_minus_${nameModelA}
                       *"JJA"*)
                           if [ $mm1 -ge 6 ] && [ $mm1 -le 8 ] ; then
                              for nameModel in $nameModelA $nameModelB ; do
-                                 pathModel="$whereexp/$nameModel/1p00/dailymean"
-                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.1p00.nc >> ${varModel}-${nameModel}-list.txt
+                                 pathModel="$whereexp/$nameModel/${res}/dailymean"
+                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.${res}.nc >> ${varModel}-${nameModel}-list.txt
                              done
                                  LENGTH="$(($LENGTH+1))"                       # How many ICs are considered
                           fi
@@ -164,16 +169,16 @@ nameModelBA=${nameModelB}_minus_${nameModelA}
                       *"SON"*)
                           if [ $mm1 -ge 9 ] && [ $mm1 -le 11 ] ; then
                              for nameModel in $nameModelA $nameModelB ; do
-                                 pathModel="$whereexp/$nameModel/1p00/dailymean"
-                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.1p00.nc >> ${varModel}-${nameModel}-list.txt
+                                 pathModel="$whereexp/$nameModel/${res}/dailymean"
+                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.${res}.nc >> ${varModel}-${nameModel}-list.txt
                              done
                                  LENGTH="$(($LENGTH+1))"                       # How many ICs are considered
                           fi
                       ;;
                       *"AllAvailable"*)
                              for nameModel in $nameModelA $nameModelB ; do
-                                 pathModel="$whereexp/$nameModel/1p00/dailymean"
-                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.1p00.nc >> ${varModel}-${nameModel}-list.txt
+                                 pathModel="$whereexp/$nameModel/${res}/dailymean"
+                                 ls -d -1 $pathModel/${tag}/${varModel}.${nameModel}.${tag}.dailymean.${res}.nc >> ${varModel}-${nameModel}-list.txt
                              done
                                  LENGTH="$(($LENGTH+1))"                       # How many ICs are considered
                       ;;
@@ -208,7 +213,7 @@ nameModelBA=${nameModelB}_minus_${nameModelA}
 ###################################################################################################
 
 echo $iclist
-nclscript="map_${season}.ncl"                         # Name for the NCL script to be created
+nclscript="map_${season}.polar.ncl"                         # Name for the NCL script to be created
 cat << EOF > $nclscript
 
   if isStrSubset("$hardcopy","yes") then
@@ -240,7 +245,7 @@ cat << EOF > $nclscript
   ${nameModelA}_add = addfiles (${nameModelA}_list, "r")   ; note the "s" of addfile
   ${nameModelB}_add = addfiles (${nameModelB}_list, "r")   
 
-  maskMod=addfile("$whereexp/${nameModelA}/1p00/dailymean/20120101/land.${nameModelA}.20120101.dailymean.1p00.nc", "r")
+  maskMod=addfile("$whereexp/${nameModelA}/${res}/dailymean/20120101/land.${nameModelA}.20120101.dailymean.${res}.nc", "r")
   masker=maskMod->LAND_surface(0,{${latS}:${latN}},{${lonW}:${lonE}})
   ;masker=where(masker.lt.1,masker,masker@_FillValue)
   masker=where(masker.ne.1,masker,masker@_FillValue)
@@ -254,8 +259,14 @@ cat << EOF > $nclscript
   ${nameModelA}_lat_0=${nameModelA}_add[:]->latitude
   ${nameModelA}_lon_0=${nameModelA}_add[:]->longitude
 
-  ${nameModelA}_fld = ${nameModelA}_add[:]->${ncvarModel}
-  ${nameModelB}_fld = ${nameModelB}_add[:]->${ncvarModel}
+  nameA=getfilevarnames(${nameModelA}_add[0])
+  nameB=getfilevarnames(${nameModelB}_add[0])
+
+  ${nameModelA}_fld = ${nameModelA}_add[:]->\$nameA(4)\$
+  ${nameModelB}_fld = ${nameModelB}_add[:]->\$nameB(4)\$
+
+  ;${nameModelA}_fld = ${nameModelA}_add[:]->${ncvarModel}
+  ;${nameModelB}_fld = ${nameModelB}_add[:]->${ncvarModel}
 
 
   lat_0 = ${nameModelA}_lat_0(0,{${latS}:${latN}})
@@ -343,7 +354,7 @@ cat << EOF > $nclscript
   ${nameModelBA}_diff@long_name="Difference" +"; mean=" + ${nameModelBA}_aave + "; min=" + amin + "; max=" + amax
   ratio@long_name="Percent Change"
 
-  plot=new(1,graphic)
+  plot=new($nplots,graphic)
 
   res                     = True
   if (isStrSubset("$domain","CONUS").or.isStrSubset("$domain","NAM")) then
@@ -412,10 +423,11 @@ cat << EOF > $nclscript
       res2@cnLevels             = (/ -40., -20., -10.,-5.,-2., 2. ,5. ,10. ,20. , 40./)   ; set levels
 
   end if
-  if (isStrSubset("{$varModel}","cloud")) then
+  if (isStrSubset("{$varModel}","oldcloud")) then
        cmap=read_colormap_file("MPL_gnuplot")
        cmap = cmap(::-1,:)
        res0@cnFillPalette = cmap
+
        res0@cnMinLevelValF  = 10.
        res0@cnMaxLevelValF  = 90.
        res0@cnLevelSpacingF  = 10.
@@ -424,6 +436,33 @@ cat << EOF > $nclscript
        res1@cnLevelSelectionMode = "ExplicitLevels"   ; set explicit contour levels
        res1@cnLevels             = (/ -40., -20., -10.,-5.,-2., 2. ,5. ,10. ,20. , 40./)   ; set levels
        res1@cnFillColors         = (/ 11,  10,   9,    8,   7,  6,  5,  4,  3,    2,  1/)  ; set the colors to be used
+
+
+       res2=res1
+       res2@cnLevelSelectionMode = "ExplicitLevels"   ; set explicit contour levels
+       res2@cnLevels             = (/ -40., -20., -10.,-5.,-2., 2. ,5. ,10. ,20. , 40./)   ; set levels
+       res2@cnFillColors         = (/ 11,  10,   9,    8,   7,  6,  5,  4,  3,    2,  1/)  ; set the colors to be used
+  end if
+  if (isStrSubset("{$varModel}","cloud")) then
+       cmap=read_colormap_file("MPL_gnuplot")
+       cmap = cmap(::-1,:)
+;       res0@cnFillPalette = cmap
+
+;       res0@cnFillPalette="precip3_16lev"
+       res0@cnFillPalette="CBR_wet"
+
+
+       res0@cnMinLevelValF  = 10.
+       res0@cnMaxLevelValF  = 90.
+       res0@cnLevelSpacingF  = 10.
+
+;       res1@cnFillPalette        = "sunshine_diff_12lev"
+;       res1@cnFillPalette="precip3_16lev"
+       res1@cnFillPalette="precip_diff_12lev"
+       res1@cnLevelSelectionMode = "ExplicitLevels"   ; set explicit contour levels
+       res1@cnLevels             = (/ -40., -20., -10.,-5.,-2., 2. ,5. ,10. ,20. , 40./)   ; set levels
+       res1@cnFillColors         = (/ 11,  10,   9,    8,   7,  6,  5,  4,  3,    2,  1/)  ; set the colors to be used
+       res1@cnFillColors         = (/ 1,  2,   3,    4,  5,  6,  7,  8,  9,    10,  11/)  ; set the colors to be used
 
 
        res2=res1
@@ -537,7 +576,7 @@ cat << EOF > $nclscript
       res2@cnLevels             = (/ -40., -20., -10.,-5.,-2., 2. ,5. ,10. ,20. , 40./)   ; set levels
   end if
 
-  if (isStrSubset("{$varModel}","snow").or.isStrSubset("{$varModel}","icec")) then
+  if (isStrSubset("{$varModel}","snow").or.isStrSubset("{$varModel}","noticec")) then
       res0@cnFillPalette="GMT_drywet"
       res0@cnFillPalette="CBR_wet"
       res0@cnLevelSelectionMode = "ExplicitLevels"   ; set explicit contour levels
@@ -552,6 +591,24 @@ cat << EOF > $nclscript
       res2@cnMaxLevelValF  = 100.
       res2@cnLevelSpacingF  = 20.
   end if
+  if (isStrSubset("{$varModel}","snow").or.isStrSubset("{$varModel}","icec")) then
+       levs = (/0.05, 0.95, 0.1/)
+       levs = (/5., 95., 10./)
+       colormap = "amwg256"
+       
+       res0@cnFillPalette = colormap
+       res0@cnLevelSelectionMode = "ManualLevels"     ; set the contour levels with the following 3 resources
+       res0@cnMinLevelValF  = levs(0)                      ; set the minimum contour level
+       res0@cnMaxLevelValF  = levs(1)                      ; set the maximum contour level
+       res0@cnLevelSpacingF = levs(2)                      ; set the interval between contours
+
+      res1@cnFillPalette="precip_diff_12lev"
+      res1@cnLevelSelectionMode = "ExplicitLevels"   ; set explicit contour levels
+      res1@cnLevels             = (/ -50., -25., -10., -5.,-1., 1.,5., 10., 25., 50. /)   ; set levels
+   end if
+       
+
+
 
   if (isStrSubset("{$varModel}","wrf")) then
        cmap=read_colormap_file("MPL_gnuplot")
@@ -570,9 +627,8 @@ cat << EOF > $nclscript
        res2@cnLevelSelectionMode = "ExplicitLevels"   ; set explicit contour levels
        res2@cnLevels             = (/ -40., -20., -10.,-5.,-2., 2. ,5. ,10. ,20. , 40./)   ; set levels
   end if 
-  res1@mpGeophysicalLineThicknessF=0.3
-
-  plot(0) = gsn_csm_contour_map_polar(wks,${nameModelBA}_diff,res1)
+  ;res1@mpGeophysicalLineThicknessF=0.3
+  
 
 
   panelopts                   = True
@@ -586,11 +642,21 @@ cat << EOF > $nclscript
   panelopts@gsnPanelYWhiteSpacePercent = 0
   panelopts@gsnPanelXWhiteSpacePercent = 5
   panelopts@amJust   = "TopLeft"
-  gsn_panel(wks,plot,(/1/),panelopts)
+
+  if ($nplots.eq.1) then
+   plot(0) = gsn_csm_contour_map_polar(wks,${nameModelBA}_diff,res1)
+   gsn_panel(wks,plot,(/1/),panelopts)
+  end if
+  if ($nplots.eq.3) then
+   plot(0) = gsn_csm_contour_map_polar(wks,${nameModelA}_mean,res0)
+   plot(1) = gsn_csm_contour_map_polar(wks,${nameModelB}_mean,res0)
+   plot(2) = gsn_csm_contour_map_polar(wks,${nameModelBA}_diff,res1)
+   gsn_panel(wks,plot,(/2,1/),panelopts)
+  end if
 
 EOF
 
-ncl -Q map_${season}.ncl
+ncl -Q map_${season}.polar.ncl
 
 
 

--- a/ATM/run_checking/ncl/setcolors.ncl
+++ b/ATM/run_checking/ncl/setcolors.ncl
@@ -1,6 +1,44 @@
 procedure setcolors (varname)
 
 begin
+  if (isStrSubset(varname,"u200")) then
+      res0@cnMinLevelValF  = -40.
+      res0@cnMaxLevelValF  = 40.
+      res0@cnLevelSpacingF  = 5.
+
+      res1@cnMinLevelValF  = -5.
+      res1@cnMaxLevelValF  = 5.
+      res1@cnLevelSpacingF  = 0.5
+   
+      res2=res1
+
+  end if
+  if (isStrSubset(varname,"u850")) then
+      res0@cnMinLevelValF  = -12.
+      res0@cnMaxLevelValF  = 12.
+      res0@cnLevelSpacingF  = 2.
+
+      res1@cnMinLevelValF  = -3.
+      res1@cnMaxLevelValF  = 3.
+      res1@cnLevelSpacingF  = 0.2
+
+      res2=res1
+  end if
+
+  if (isStrSubset(varname,"z500")) then
+
+       res0@cnMinLevelValF  = 5000.
+       res0@cnMaxLevelValF  = 5800.
+       res0@cnLevelSpacingF  = 50.
+
+       res1@cnMinLevelValF  = -50.
+       res1@cnMaxLevelValF  = 50.
+       res1@cnLevelSpacingF  = 5.
+
+       res2=res1
+
+  end if 
+
   if (isStrSubset(varname,"cloud")) then
        cmap=read_colormap_file("MPL_gnuplot")
        cmap = cmap(::-1,:)


### PR DESCRIPTION
The scripts under ATM were modified to allow u850, u200, z500. 
Either cfsr or era5 can be specified to be used as reference for these fields (note that currently only the cfsr data are ready to be used as such, era5 coming soon). 